### PR TITLE
Fix PhysicMaterialLibrary bug on project compile

### DIFF
--- a/Assets/Editor/GeneratePhysicMaterialLibrary.cs
+++ b/Assets/Editor/GeneratePhysicMaterialLibrary.cs
@@ -2,26 +2,51 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using UnityEditor;
+using UnityEngine;
 
 namespace Editor
 {
 	public class GeneratePhysicMaterialLibrary : AssetPostprocessor
 	{
 		private const string SUFFIX = ".physicMaterial";
-		private const string GENERATED_FILE = "Assets/Scripts/Generated/PhysicMaterialLibrary.cs";
-		private const string TEMPLATE = @"// This file was automatically generated.
-// Any modifications you do to this file will be overwritten.
 
-using UnityEditor;
+		private const string GENERATED_CODE_PATH = "Assets/Scripts/Generated/PhysicMaterialLibrary.cs";
+		private const string CODE_TEMPLATE = @"// This file and its accompanying .meta file were automatically generated.
+// Any modifications you do to either of them will be overwritten.
+
 using UnityEngine;
 
 namespace Generated
 {
-	public static class PhysicMaterialLibrary
+	public class PhysicMaterialLibrary : ScriptableObject
 	{
-//here
-	}
-}";
+		private static PhysicMaterialLibrary _instance;
+		private void Awake() => _instance = Resources.Load<PhysicMaterialLibrary>(""PhysicMaterialLibrary"");
+		private void OnEnable() => Awake();
+";
+		private const string CODE_LINE_TEMPLATE = @"
+		public static PhysicMaterial {0} => _instance.prop{0};
+		[SerializeField] private PhysicMaterial prop{0};
+";
+
+		private const string GENERATED_ASSET_PATH = "Assets/Scripts/Generated/Resources/PhysicMaterialLibrary.asset";
+		private const string ASSET_TEMPLATE = @"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3fd5956597cab9dc8683d072d84ec79, type: 3}
+  m_Name: PhysicMaterialLibrary
+  m_EditorClassIdentifier: 
+";
+
+		private const string ASSET_LINE_TEMPLATE = "  prop[name]: {fileID: 13400000, guid: [guid], type: 2}";
 
 		private static void OnPostprocessAllAssets(
 			string[] importedAssets,
@@ -42,15 +67,26 @@ namespace Generated
 		private static void Generate()
 		{
 			string[] guids = AssetDatabase.FindAssets("t:PhysicMaterial");
-			StringBuilder insert = new();
+			StringBuilder code = new(CODE_TEMPLATE);
+			StringBuilder asset = new(ASSET_TEMPLATE);
 			foreach (string guid in guids)
 			{
 				string path = AssetDatabase.GUIDToAssetPath(guid);
 				string name = Path.GetFileNameWithoutExtension(path);
-				insert.AppendLine($"\t\tpublic static PhysicMaterial {name} => AssetDatabase.LoadAssetAtPath<PhysicMaterial>(\"{path}\");");
+				if (name.Contains(" "))
+				{
+					Debug.LogError($"PhysicMaterial name '{name}' contains spaces. This is not allowed. Please rename the PhysicMaterial. Aborting code generation.");
+					return;
+				}
+
+				code.AppendFormat(CODE_LINE_TEMPLATE, name);
+				asset.AppendLine(ASSET_LINE_TEMPLATE.Replace("[name]", name).Replace("[guid]", guid));
 			}
 
-			File.WriteAllText(GENERATED_FILE, TEMPLATE.Replace("//here", insert.ToString()));
+			code.AppendLine("\t}\n}");
+
+			File.WriteAllText(GENERATED_CODE_PATH, code.ToString());
+			File.WriteAllText(GENERATED_ASSET_PATH, asset.ToString());
 			AssetDatabase.Refresh();
 		}
 	}

--- a/Assets/Scripts/Generated/PhysicMaterialLibrary.cs
+++ b/Assets/Scripts/Generated/PhysicMaterialLibrary.cs
@@ -1,16 +1,23 @@
-// This file was automatically generated.
-// Any modifications you do to this file will be overwritten.
+// This file and its accompanying .meta file were automatically generated.
+// Any modifications you do to either of them will be overwritten.
 
-using UnityEditor;
 using UnityEngine;
 
 namespace Generated
 {
-	public static class PhysicMaterialLibrary
+	public class PhysicMaterialLibrary : ScriptableObject
 	{
-		public static PhysicMaterial Grass => AssetDatabase.LoadAssetAtPath<PhysicMaterial>("Assets/PhysicMaterials/Grass.physicMaterial");
-		public static PhysicMaterial Track => AssetDatabase.LoadAssetAtPath<PhysicMaterial>("Assets/PhysicMaterials/Track.physicMaterial");
-		public static PhysicMaterial Water => AssetDatabase.LoadAssetAtPath<PhysicMaterial>("Assets/PhysicMaterials/Water.physicMaterial");
+		private static PhysicMaterialLibrary _instance;
+		private void Awake() => _instance = Resources.Load<PhysicMaterialLibrary>("PhysicMaterialLibrary");
+		private void OnEnable() => Awake();
 
+		public static PhysicMaterial Grass => _instance.propGrass;
+		[SerializeField] private PhysicMaterial propGrass;
+
+		public static PhysicMaterial Track => _instance.propTrack;
+		[SerializeField] private PhysicMaterial propTrack;
+
+		public static PhysicMaterial Water => _instance.propWater;
+		[SerializeField] private PhysicMaterial propWater;
 	}
 }

--- a/Assets/Scripts/Generated/Resources.meta
+++ b/Assets/Scripts/Generated/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 701f84d632bb1b646947ff7f78b13159
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Generated/Resources/PhysicMaterialLibrary.asset
+++ b/Assets/Scripts/Generated/Resources/PhysicMaterialLibrary.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3fd5956597cab9dc8683d072d84ec79, type: 3}
+  m_Name: PhysicMaterialLibrary
+  m_EditorClassIdentifier: 
+  propGrass: {fileID: 13400000, guid: df83f1c51af34bc63a3c4d86e8148c61, type: 2}
+  propTrack: {fileID: 13400000, guid: 4f60272a7a5b62370b15013a86bafeff, type: 2}
+  propWater: {fileID: 13400000, guid: 321fc3f7b0ee2534cbc7c439c39f47e6, type: 2}

--- a/Assets/Scripts/Generated/Resources/PhysicMaterialLibrary.asset.meta
+++ b/Assets/Scripts/Generated/Resources/PhysicMaterialLibrary.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6f120db27b12dcd58e2417c32630f3f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
AssetDatabase is apparently not supported outside of the editor, so I had to create a workaround. It was a right pain, but I feel like I've got it working now.